### PR TITLE
use alpine 3.13, glibc 2.33, and su-exec instead of gosu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,58 +1,46 @@
-FROM alpine:3.12
+FROM alpine:3.13
 
 SHELL ["/bin/ash", "-x", "-c", "-o", "pipefail"]
 
 # Based on https://github.com/djenriquez/nomad
 LABEL maintainer="Jonathan Ballet <jon@multani.info>"
 
-RUN addgroup nomad && \
-    adduser -S -G nomad nomad
+RUN addgroup nomad \
+ && adduser -S -G nomad nomad \
+ && mkdir -p /nomad/data \
+ && mkdir -p /etc/nomad \
+ && chown -R nomad:nomad /nomad /etc/nomad
 
 # Allow to fetch artifacts from TLS endpoint during the builds and by Nomad after.
+# Install timezone data so we can run Nomad periodic jobs containing timezone information
 RUN apk --update --no-cache add \
         ca-certificates \
+        dumb-init \
+        libcap \
+        tzdata \
+        su-exec \
   && update-ca-certificates
 
-
 # https://github.com/sgerrand/alpine-pkg-glibc/releases
-ENV GLIBC_VERSION "2.32-r0"
+ARG GLIBC_VERSION=2.33-r0
 
-RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
-    wget -q -O glibc.apk https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk && \
-    apk add --no-cache \
-        glibc.apk && \
-    rm glibc.apk
-
+ADD https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub /etc/apk/keys/sgerrand.rsa.pub
+ADD https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk \
+    glibc.apk
 RUN apk add --no-cache \
-        dumb-init
-
-# Install timezone data so we can run Nomad periodic jobs containing timezone information
-RUN apk add --no-cache \
-        tzdata
-
-# https://github.com/tianon/gosu/releases
-ENV GOSU_VERSION "1.12"
-
-RUN apk --update add --no-cache --virtual .gosu-deps dpkg gnupg && \
-    dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" && \
-    wget -q -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" && \
-    wget -q -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" && \
-    GNUPGHOME="$(mktemp -d)" && \
-    export GNUPGHOME && \
-    gpg --keyserver pgp.mit.edu --keyserver keyserver.pgp.com --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && \
-    gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \
-    rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc && \
-    chmod +x /usr/local/bin/gosu && \
-    gosu nobody true && \
-    apk del .gosu-deps
+        glibc.apk \
+ && rm glibc.apk
 
 # https://releases.hashicorp.com/nomad/
-ENV NOMAD_VERSION 1.0.4
+ARG NOMAD_VERSION=1.0.4
 
-RUN apk --update add --no-cache --virtual .nomad-deps dpkg gnupg \
-  && wget -q -O nomad_${NOMAD_VERSION}_linux_amd64.zip https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip \
-  && wget -q -O nomad_${NOMAD_VERSION}_SHA256SUMS      https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_SHA256SUMS \
-  && wget -q -O nomad_${NOMAD_VERSION}_SHA256SUMS.sig  https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
+ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip \
+    nomad_${NOMAD_VERSION}_linux_amd64.zip
+ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_SHA256SUMS \
+    nomad_${NOMAD_VERSION}_SHA256SUMS
+ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
+    nomad_${NOMAD_VERSION}_SHA256SUMS.sig
+RUN apk add --no-cache --virtual .nomad-deps gnupg \
   && GNUPGHOME="$(mktemp -d)" \
   && export GNUPGHOME \
   && gpg --keyserver pgp.mit.edu --keyserver keyserver.pgp.com --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C \
@@ -62,10 +50,6 @@ RUN apk --update add --no-cache --virtual .nomad-deps dpkg gnupg \
   && chmod +x /bin/nomad \
   && rm -rf "$GNUPGHOME" nomad_${NOMAD_VERSION}_linux_amd64.zip nomad_${NOMAD_VERSION}_SHA256SUMS nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
   && apk del .nomad-deps
-
-RUN mkdir -p /nomad/data && \
-    mkdir -p /etc/nomad && \
-    chown -R nomad:nomad /nomad /etc/nomad
 
 EXPOSE 4646 4647 4648 4648/udp
 

--- a/start.sh
+++ b/start.sh
@@ -45,7 +45,7 @@ elif nomad --help "$1" 2>&1 | grep -q "nomad $1"; then
 fi
 
 # If we are running Nomad, make sure it executes as the proper user.
-if [ "$1" = 'nomad' -a -z "${NOMAD_DISABLE_PERM_MGMT+x}" ]; then
+if [ "$1" = 'nomad' ] && [ -z "${NOMAD_DISABLE_PERM_MGMT+x}" ]; then
     # If the data or config dirs are bind mounted then chown them.
     # Note: This checks for root ownership as that's the most common case.
     if [ "$(stat -c %u $NOMAD_DATA_DIR)" != "$(id -u root)" ]; then
@@ -55,11 +55,11 @@ if [ "$1" = 'nomad' -a -z "${NOMAD_DISABLE_PERM_MGMT+x}" ]; then
     # If requested, set the capability to bind to privileged ports before
     # we drop to the non-root user. Note that this doesn't work with all
     # storage drivers (it won't work with AUFS).
-    if [ ! -z ${NOMAD+x} ]; then
+    if [ -n ${NOMAD+x} ]; then
         setcap "cap_net_bind_service=+ep" /bin/nomad
     fi
 
-    set -- gosu root "$@"
+    set -- su-exec root "$@"
 fi
 
 exec "$@"


### PR DESCRIPTION
So changes I had sitting on my box for a while. A mix bag.

It's been packaged in alpinelinux, https://git.alpinelinux.org/aports/tree/community/nomad?h=master