### PR TITLE
Build on arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Docker build
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   test:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,5 +14,17 @@ jobs:
       - name: Lint the Dockerfile
         uses: hadolint/hadolint-action@v2.1.0
 
-      - name: Build the Docker image
-        run: docker build .
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        id: buildx
+        with:
+          install: true
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: false
+          platforms: ${{ steps.buildx.outputs.platforms }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
         with:
-          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64,linux/arm64,linux/386
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
+        with:
+          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,12 +50,25 @@ jobs:
             type=raw,value=latest
             type=sha
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        id: buildx
+        with:
+          install: true
+
+      - name: Build the Docker image
+        run: docker buildx build --platform=${{ steps.buildx.outputs.platforms }} .
+
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
           push: true
           tags: ${{ steps.docker-meta.outputs.tags }}
           labels: ${{ steps.docker-meta.outputs.labels }}
+          platforms: ${{ steps.buildx.outputs.platforms }}
 
       - name: Nomad tag
         id: nomad

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,6 +52,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
+        with:
+          platforms: linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,10 @@ RUN groupadd nomad \
  && chown -R nomad:nomad /nomad /etc/nomad
 
 # Allow to fetch artifacts from TLS endpoint during the builds and by Nomad after.
-# Install timezone data so we can run Nomad periodic jobs containing timezone information
 RUN apt-get update --yes \
     && apt-get install --no-install-recommends --yes \
-        ca-certificates \
-        dumb-init \
-        tzdata \
+        ca-certificates=20210119 \
+        dumb-init=1.2.5-1 \
     && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
@@ -37,8 +35,8 @@ ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}
     nomad_${NOMAD_VERSION}_SHA256SUMS.sig
 RUN apt-get update \
 && apt-get install --no-install-recommends --yes \
-    gnupg \
-    unzip  \
+    gnupg=2.2.27-2+deb11u2 \
+    unzip=6.0-26+deb11u1 \
   && GNUPGHOME="$(mktemp -d)" \
   && export GNUPGHOME \
   && gpg --keyserver pgp.mit.edu --keyserver keys.openpgp.org --keyserver keyserver.ubuntu.com --recv-keys "C874 011F 0AB4 0511 0D02 1055 3436 5D94 72D7 468F" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ SHELL ["/bin/bash", "-x", "-c", "-o", "pipefail"]
 # Based on https://github.com/djenriquez/nomad
 LABEL maintainer="Jonathan Ballet <jon@multani.info>"
 
-RUN addgroup nomad \
- && adduser --ingroup nomad nomad \
+RUN groupadd nomad \
+ && useradd --gid nomad nomad \
  && mkdir -p /nomad/data \
  && mkdir -p /etc/nomad \
  && chown -R nomad:nomad /nomad /etc/nomad

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN addgroup nomad \
 # Allow to fetch artifacts from TLS endpoint during the builds and by Nomad after.
 # Install timezone data so we can run Nomad periodic jobs containing timezone information
 RUN apt-get update --yes \
-    && apt-get install --yes \
+    && apt-get install --no-install-recommends --yes \
         ca-certificates \
         dumb-init \
         tzdata \
@@ -35,7 +35,9 @@ ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}
 ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
     nomad_${NOMAD_VERSION}_SHA256SUMS.sig
 RUN apt-get update \
-&& apt-get install gnupg unzip --yes \
+&& apt-get install --no-install-recommends --yes \
+    gnupg \
+    unzip  \
   && GNUPGHOME="$(mktemp -d)" \
   && export GNUPGHOME \
   && gpg --keyserver pgp.mit.edu --keyserver keys.openpgp.org --keyserver keyserver.ubuntu.com --recv-keys "C874 011F 0AB4 0511 0D02 1055 3436 5D94 72D7 468F" \
@@ -44,7 +46,9 @@ RUN apt-get update \
   && unzip -d /bin nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip \
   && chmod +x /bin/nomad \
   && rm -rf "$GNUPGHOME" nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip nomad_${NOMAD_VERSION}_SHA256SUMS nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
-  && apt autoremove --purge --yes gnupg unzip \
+  && apt-get autoremove --purge --yes \
+    gnupg \
+    unzip \
   && rm -rf /var/lib/apt/lists/*
 
 RUN nomad version

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,6 @@ RUN apt-get update \
     unzip \
   && rm -rf /var/lib/apt/lists/*
 
-RUN nomad version
-
 EXPOSE 4646 4647 4648 4648/udp
 
 COPY start.sh /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM --platform=$BUILDPLATFORM debian:bullseye-slim
+FROM debian:bullseye-slim
+#FROM --platform=$BUILDPLATFORM debian:bullseye-slim
 
 # Fetch the target information injected by Docker build
 ARG TARGETOS

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,55 +1,53 @@
-FROM alpine:3.16.2
+FROM --platform=$BUILDPLATFORM debian:bullseye-slim
 
-SHELL ["/bin/ash", "-x", "-c", "-o", "pipefail"]
+# Fetch the target information injected by Docker build
+ARG TARGETOS
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-x", "-c", "-o", "pipefail"]
 
 # Based on https://github.com/djenriquez/nomad
 LABEL maintainer="Jonathan Ballet <jon@multani.info>"
 
 RUN addgroup nomad \
- && adduser -S -G nomad nomad \
+ && adduser --ingroup nomad nomad \
  && mkdir -p /nomad/data \
  && mkdir -p /etc/nomad \
  && chown -R nomad:nomad /nomad /etc/nomad
 
 # Allow to fetch artifacts from TLS endpoint during the builds and by Nomad after.
 # Install timezone data so we can run Nomad periodic jobs containing timezone information
-RUN apk --update --no-cache add \
+RUN apt-get update --yes \
+    && apt-get install --yes \
         ca-certificates \
         dumb-init \
-        libcap \
         tzdata \
-        su-exec \
-  && update-ca-certificates
-
-# https://github.com/sgerrand/alpine-pkg-glibc/releases
-ARG GLIBC_VERSION=2.33-r0
-
-ADD https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub /etc/apk/keys/sgerrand.rsa.pub
-ADD https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk \
-    glibc.apk
-RUN apk add --no-cache \
-        glibc.apk \
- && rm glibc.apk
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
 # https://releases.hashicorp.com/nomad/
 ARG NOMAD_VERSION=1.3.5
 
-ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip \
-    nomad_${NOMAD_VERSION}_linux_amd64.zip
+ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip \
+    nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip
 ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_SHA256SUMS \
     nomad_${NOMAD_VERSION}_SHA256SUMS
 ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
     nomad_${NOMAD_VERSION}_SHA256SUMS.sig
-RUN apk add --no-cache --virtual .nomad-deps gnupg \
+RUN apt-get update \
+&& apt-get install gnupg unzip --yes \
   && GNUPGHOME="$(mktemp -d)" \
   && export GNUPGHOME \
   && gpg --keyserver pgp.mit.edu --keyserver keys.openpgp.org --keyserver keyserver.ubuntu.com --recv-keys "C874 011F 0AB4 0511 0D02 1055 3436 5D94 72D7 468F" \
   && gpg --batch --verify nomad_${NOMAD_VERSION}_SHA256SUMS.sig nomad_${NOMAD_VERSION}_SHA256SUMS \
-  && grep nomad_${NOMAD_VERSION}_linux_amd64.zip nomad_${NOMAD_VERSION}_SHA256SUMS | sha256sum -c \
-  && unzip -d /bin nomad_${NOMAD_VERSION}_linux_amd64.zip \
+  && grep nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip nomad_${NOMAD_VERSION}_SHA256SUMS | sha256sum -c \
+  && unzip -d /bin nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip \
   && chmod +x /bin/nomad \
-  && rm -rf "$GNUPGHOME" nomad_${NOMAD_VERSION}_linux_amd64.zip nomad_${NOMAD_VERSION}_SHA256SUMS nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
-  && apk del .nomad-deps
+  && rm -rf "$GNUPGHOME" nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip nomad_${NOMAD_VERSION}_SHA256SUMS nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
+  && apt autoremove --purge --yes gnupg unzip \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN nomad version
 
 EXPOSE 4646 4647 4648 4648/udp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM debian:bullseye-slim
-#FROM --platform=$BUILDPLATFORM debian:bullseye-slim
+FROM --platform=$BUILDPLATFORM debian:bullseye-slim
 
 # Fetch the target information injected by Docker build
 ARG TARGETOS


### PR DESCRIPTION
Cf. https://github.com/multani/docker-nomad/discussions/38

[Nomad still needs the glibc](https://github.com/hashicorp/nomad/issues/5643) and it's difficult to find a maintained glibc package for Alpine, built for arm64. So, this switches the base image from Alpine to Debian.

Quick testing shows the new base image adds 60 MB:

```
$ docker images | grep nomad
local/nomad       debian         702bf83325e9   15 minutes ago      211MB
local/nomad       alpine         96d0438abfd1   15 minutes ago      149MB
```