### PR TITLE
feat: replace glibc with gcompat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,20 +16,11 @@ RUN addgroup nomad \
 RUN apk --update --no-cache add \
         ca-certificates \
         dumb-init \
+        gcompat \
         libcap \
         tzdata \
         su-exec \
   && update-ca-certificates
-
-# https://github.com/sgerrand/alpine-pkg-glibc/releases
-ARG GLIBC_VERSION=2.34-r0
-
-ADD https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub /etc/apk/keys/sgerrand.rsa.pub
-ADD https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk \
-    glibc.apk
-RUN apk add --no-cache --force-overwrite \
-        glibc.apk \
- && rm glibc.apk
 
 # https://releases.hashicorp.com/nomad/
 ARG NOMAD_VERSION=1.4.3

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ image](https://github.com/hashicorp/docker-consul). It is based on the work from
 You can use the Docker Compose file to get started:
 
 ```bash
-docker-compose up
+docker compose up
 ```
 
 The relevant Docker Compose bits are:


### PR DESCRIPTION
> gcompat is the go-to compatibility layer for Alpine users. 
>
> https://wiki.alpinelinux.org/wiki/Running_glibc_programs

It will help with #55 