### PR TITLE
Revert "feat: replace glibc with gcompat (#74)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,20 @@ RUN addgroup nomad \
 RUN apk --update --no-cache add \
         ca-certificates \
         dumb-init \
-        gcompat \
         libcap \
         tzdata \
         su-exec \
   && update-ca-certificates
+
+# https://github.com/sgerrand/alpine-pkg-glibc/releases
+ARG GLIBC_VERSION=2.34-r0
+
+ADD https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub /etc/apk/keys/sgerrand.rsa.pub
+ADD https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk \
+    glibc.apk
+RUN apk add --no-cache --force-overwrite \
+        glibc.apk \
+ && rm glibc.apk
 
 # https://releases.hashicorp.com/nomad/
 ARG NOMAD_VERSION=1.4.3

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ image](https://github.com/hashicorp/docker-consul). It is based on the work from
 You can use the Docker Compose file to get started:
 
 ```bash
-docker compose up
+docker-compose up
 ```
 
 The relevant Docker Compose bits are:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ image](https://github.com/hashicorp/docker-consul). It is based on the work from
 You can use the Docker Compose file to get started:
 
 ```bash
-docker-compose up
+docker compose up
 ```
 
 The relevant Docker Compose bits are:


### PR DESCRIPTION
This reverts commit a06de6901d5f84d7e95998a2a18dab3a32004f80.

Weirdly, #74 worked with Nomad 1.4.3 but not Nomad 1.5.0-beta.1