### PR TITLE
Ensure bind mount compatible version of df is used

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apk --update --no-cache add \
         libcap \
         tzdata \
         su-exec \
+        coreutils \ # ensure bind mount compatible version of df is used (related: hashicorp/nomad#12440, gliderlabs/docker-alpine#97)
   && update-ca-certificates
 
 # https://github.com/sgerrand/alpine-pkg-glibc/releases


### PR DESCRIPTION
```
# -v /var/lib/nomad:/var/lib/nomad
/var/lib/nomad # df alloc
Filesystem           1K-blocks      Used Available Use% Mounted on
df: alloc: can't find mount point

/var/lib/nomad # apk -U add coreutils
[...]
OK: 17 MiB in 28 packages

/var/lib/nomad # df alloc
Filesystem     1K-blocks    Used Available Use% Mounted on
rootfs          32823212 1601280  31221932   5% /var/lib/nomad
```