### PR TITLE
Replace Alpine 3.18 by Debian 12 as the base image

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,2 +1,2 @@
 ignored:
-  - DL3018
+  - DL3008  # ignore unpinned Debian packages

--- a/v1.2.x/Dockerfile
+++ b/v1.2.x/Dockerfile
@@ -1,39 +1,27 @@
-FROM alpine:3.18.4
+FROM debian:12.2-slim
 
-SHELL ["/bin/ash", "-x", "-c", "-o", "pipefail"]
+SHELL ["/bin/bash", "-x", "-c", "-o", "pipefail"]
 
 # https://releases.hashicorp.com/nomad/
 ARG NOMAD_VERSION
 RUN test -n "$NOMAD_VERSION" || (echo "NOMAD_VERSION argument must be set" && false)
 
-# Based on https://github.com/djenriquez/nomad
-LABEL maintainer="Jonathan Ballet <jon@multani.info>"
-
-RUN addgroup nomad \
- && adduser -S -G nomad nomad \
- && mkdir -p /nomad/data \
- && mkdir -p /etc/nomad \
- && chown -R nomad:nomad /nomad /etc/nomad
+RUN groupadd nomad \
+  && useradd --system --gid nomad nomad \
+  && mkdir --parents /nomad/data \
+  && mkdir --parents /etc/nomad \
+  && chown --recursive nomad:nomad /nomad /etc/nomad
 
 # Allow to fetch artifacts from TLS endpoint during the builds and by Nomad after.
 # Install timezone data so we can run Nomad periodic jobs containing timezone information
-RUN apk --update --no-cache add \
-        ca-certificates \
-        dumb-init \
-        libcap \
-        tzdata \
-        su-exec \
-  && update-ca-certificates
-
-# https://github.com/sgerrand/alpine-pkg-glibc/releases
-ARG GLIBC_VERSION=2.34-r0
-
-ADD https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub /etc/apk/keys/sgerrand.rsa.pub
-ADD https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk \
-    glibc.apk
-RUN apk add --no-cache --force-overwrite \
-        glibc.apk \
- && rm glibc.apk
+RUN apt-get update \
+  && apt-get install --yes --no-install-recommends \
+    ca-certificates \
+    dumb-init \
+    libcap2 \
+    tzdata \
+  && update-ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 
 ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip \
     nomad_${NOMAD_VERSION}_linux_amd64.zip
@@ -41,7 +29,11 @@ ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}
     nomad_${NOMAD_VERSION}_SHA256SUMS
 ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
     nomad_${NOMAD_VERSION}_SHA256SUMS.sig
-RUN apk add --no-cache --virtual .nomad-deps gnupg \
+
+RUN apt-get update \
+  && apt-get install --yes --no-install-recommends \
+    gnupg \
+    unzip \
   && GNUPGHOME="$(mktemp -d)" \
   && export GNUPGHOME \
   && gpg --keyserver pgp.mit.edu --keyserver keys.openpgp.org --keyserver keyserver.ubuntu.com --recv-keys "C874 011F 0AB4 0511 0D02 1055 3436 5D94 72D7 468F" \
@@ -50,7 +42,12 @@ RUN apk add --no-cache --virtual .nomad-deps gnupg \
   && unzip -d /bin nomad_${NOMAD_VERSION}_linux_amd64.zip \
   && chmod +x /bin/nomad \
   && rm -rf "$GNUPGHOME" nomad_${NOMAD_VERSION}_linux_amd64.zip nomad_${NOMAD_VERSION}_SHA256SUMS nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
-  && apk del .nomad-deps
+  && apt-get autoremove --purge --yes \
+      gnupg \
+      unzip \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN nomad version
 
 EXPOSE 4646 4647 4648 4648/udp
 

--- a/v1.2.x/start.sh
+++ b/v1.2.x/start.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/dumb-init /bin/sh
-# Script created following Hashicorp's model for Consul: 
+# shellcheck shell=dash
+# Script created following Hashicorp's model for Consul:
 # https://github.com/hashicorp/docker-consul/blob/master/0.X/docker-entrypoint.sh
 # Comments in this file originate from the project above, simply replacing 'Consul' with 'Nomad'.
 set -e
@@ -8,6 +9,7 @@ set -e
 # as well as forward signals to all processes in its session. Normally, sh
 # wouldn't do either of these functions so we'd leak zombies as well as do
 # unclean termination of all our sub-processes.
+# As of docker 1.13, using docker run --init achieves the same outcome.
 
 # NOMAD_DATA_DIR is exposed as a volume for possible persistent storage. The
 # NOMAD_CONFIG_DIR isn't exposed as a volume but you can compose additional
@@ -24,7 +26,7 @@ fi
 
 # If the user is trying to run Nomad directly with some arguments, then
 # pass them to Nomad.
-if [ "${1:0:1}" = '-' ]; then
+if [ "$(cut -c 1 "$1")" = '-' ]; then
     set -- nomad "$@"
 fi
 
@@ -48,18 +50,18 @@ fi
 if [ "$1" = 'nomad' ] && [ -z "${NOMAD_DISABLE_PERM_MGMT+x}" ]; then
     # If the data or config dirs are bind mounted then chown them.
     # Note: This checks for root ownership as that's the most common case.
-    if [ "$(stat -c %u $NOMAD_DATA_DIR)" != "$(id -u root)" ]; then
-        chown root:root $NOMAD_DATA_DIR
+    if [ "$(stat -c %u "$NOMAD_DATA_DIR")" != "$(id -u root)" ]; then
+        chown root:root "$NOMAD_DATA_DIR"
     fi
 
     # If requested, set the capability to bind to privileged ports before
     # we drop to the non-root user. Note that this doesn't work with all
     # storage drivers (it won't work with AUFS).
-    if [ -n ${NOMAD+x} ]; then
+    if [ -n "${NOMAD+x}" ]; then
         setcap "cap_net_bind_service=+ep" /bin/nomad
     fi
 
-    set -- su-exec root "$@"
+    exec runuser -u root -- "$@"
 fi
 
 exec "$@"

--- a/v1.3.x/Dockerfile
+++ b/v1.3.x/Dockerfile
@@ -1,39 +1,27 @@
-FROM alpine:3.18.4
+FROM debian:12.2-slim
 
-SHELL ["/bin/ash", "-x", "-c", "-o", "pipefail"]
+SHELL ["/bin/bash", "-x", "-c", "-o", "pipefail"]
 
 # https://releases.hashicorp.com/nomad/
 ARG NOMAD_VERSION
 RUN test -n "$NOMAD_VERSION" || (echo "NOMAD_VERSION argument must be set" && false)
 
-# Based on https://github.com/djenriquez/nomad
-LABEL maintainer="Jonathan Ballet <jon@multani.info>"
-
-RUN addgroup nomad \
- && adduser -S -G nomad nomad \
- && mkdir -p /nomad/data \
- && mkdir -p /etc/nomad \
- && chown -R nomad:nomad /nomad /etc/nomad
+RUN groupadd nomad \
+  && useradd --system --gid nomad nomad \
+  && mkdir --parents /nomad/data \
+  && mkdir --parents /etc/nomad \
+  && chown --recursive nomad:nomad /nomad /etc/nomad
 
 # Allow to fetch artifacts from TLS endpoint during the builds and by Nomad after.
 # Install timezone data so we can run Nomad periodic jobs containing timezone information
-RUN apk --update --no-cache add \
-        ca-certificates \
-        dumb-init \
-        libcap \
-        tzdata \
-        su-exec \
-  && update-ca-certificates
-
-# https://github.com/sgerrand/alpine-pkg-glibc/releases
-ARG GLIBC_VERSION=2.34-r0
-
-ADD https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub /etc/apk/keys/sgerrand.rsa.pub
-ADD https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk \
-    glibc.apk
-RUN apk add --no-cache --force-overwrite \
-        glibc.apk \
- && rm glibc.apk
+RUN apt-get update \
+  && apt-get install --yes --no-install-recommends \
+    ca-certificates \
+    dumb-init \
+    libcap2 \
+    tzdata \
+  && update-ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 
 ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip \
     nomad_${NOMAD_VERSION}_linux_amd64.zip
@@ -41,7 +29,11 @@ ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}
     nomad_${NOMAD_VERSION}_SHA256SUMS
 ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
     nomad_${NOMAD_VERSION}_SHA256SUMS.sig
-RUN apk add --no-cache --virtual .nomad-deps gnupg \
+
+RUN apt-get update \
+  && apt-get install --yes --no-install-recommends \
+    gnupg \
+    unzip \
   && GNUPGHOME="$(mktemp -d)" \
   && export GNUPGHOME \
   && gpg --keyserver pgp.mit.edu --keyserver keys.openpgp.org --keyserver keyserver.ubuntu.com --recv-keys "C874 011F 0AB4 0511 0D02 1055 3436 5D94 72D7 468F" \
@@ -50,7 +42,12 @@ RUN apk add --no-cache --virtual .nomad-deps gnupg \
   && unzip -d /bin nomad_${NOMAD_VERSION}_linux_amd64.zip \
   && chmod +x /bin/nomad \
   && rm -rf "$GNUPGHOME" nomad_${NOMAD_VERSION}_linux_amd64.zip nomad_${NOMAD_VERSION}_SHA256SUMS nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
-  && apk del .nomad-deps
+  && apt-get autoremove --purge --yes \
+      gnupg \
+      unzip \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN nomad version
 
 EXPOSE 4646 4647 4648 4648/udp
 

--- a/v1.3.x/start.sh
+++ b/v1.3.x/start.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/dumb-init /bin/sh
-# Script created following Hashicorp's model for Consul: 
+# shellcheck shell=dash
+# Script created following Hashicorp's model for Consul:
 # https://github.com/hashicorp/docker-consul/blob/master/0.X/docker-entrypoint.sh
 # Comments in this file originate from the project above, simply replacing 'Consul' with 'Nomad'.
 set -e
@@ -8,6 +9,7 @@ set -e
 # as well as forward signals to all processes in its session. Normally, sh
 # wouldn't do either of these functions so we'd leak zombies as well as do
 # unclean termination of all our sub-processes.
+# As of docker 1.13, using docker run --init achieves the same outcome.
 
 # NOMAD_DATA_DIR is exposed as a volume for possible persistent storage. The
 # NOMAD_CONFIG_DIR isn't exposed as a volume but you can compose additional
@@ -24,7 +26,7 @@ fi
 
 # If the user is trying to run Nomad directly with some arguments, then
 # pass them to Nomad.
-if [ "${1:0:1}" = '-' ]; then
+if [ "$(cut -c 1 "$1")" = '-' ]; then
     set -- nomad "$@"
 fi
 
@@ -48,18 +50,18 @@ fi
 if [ "$1" = 'nomad' ] && [ -z "${NOMAD_DISABLE_PERM_MGMT+x}" ]; then
     # If the data or config dirs are bind mounted then chown them.
     # Note: This checks for root ownership as that's the most common case.
-    if [ "$(stat -c %u $NOMAD_DATA_DIR)" != "$(id -u root)" ]; then
-        chown root:root $NOMAD_DATA_DIR
+    if [ "$(stat -c %u "$NOMAD_DATA_DIR")" != "$(id -u root)" ]; then
+        chown root:root "$NOMAD_DATA_DIR"
     fi
 
     # If requested, set the capability to bind to privileged ports before
     # we drop to the non-root user. Note that this doesn't work with all
     # storage drivers (it won't work with AUFS).
-    if [ -n ${NOMAD+x} ]; then
+    if [ -n "${NOMAD+x}" ]; then
         setcap "cap_net_bind_service=+ep" /bin/nomad
     fi
 
-    set -- su-exec root "$@"
+    exec runuser -u root -- "$@"
 fi
 
 exec "$@"

--- a/v1.4.x/Dockerfile
+++ b/v1.4.x/Dockerfile
@@ -1,39 +1,27 @@
-FROM alpine:3.18.4
+FROM debian:12.2-slim
 
-SHELL ["/bin/ash", "-x", "-c", "-o", "pipefail"]
+SHELL ["/bin/bash", "-x", "-c", "-o", "pipefail"]
 
 # https://releases.hashicorp.com/nomad/
 ARG NOMAD_VERSION
 RUN test -n "$NOMAD_VERSION" || (echo "NOMAD_VERSION argument must be set" && false)
 
-# Based on https://github.com/djenriquez/nomad
-LABEL maintainer="Jonathan Ballet <jon@multani.info>"
-
-RUN addgroup nomad \
- && adduser -S -G nomad nomad \
- && mkdir -p /nomad/data \
- && mkdir -p /etc/nomad \
- && chown -R nomad:nomad /nomad /etc/nomad
+RUN groupadd nomad \
+  && useradd --system --gid nomad nomad \
+  && mkdir --parents /nomad/data \
+  && mkdir --parents /etc/nomad \
+  && chown --recursive nomad:nomad /nomad /etc/nomad
 
 # Allow to fetch artifacts from TLS endpoint during the builds and by Nomad after.
 # Install timezone data so we can run Nomad periodic jobs containing timezone information
-RUN apk --update --no-cache add \
-        ca-certificates \
-        dumb-init \
-        libcap \
-        tzdata \
-        su-exec \
-  && update-ca-certificates
-
-# https://github.com/sgerrand/alpine-pkg-glibc/releases
-ARG GLIBC_VERSION=2.34-r0
-
-ADD https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub /etc/apk/keys/sgerrand.rsa.pub
-ADD https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk \
-    glibc.apk
-RUN apk add --no-cache --force-overwrite \
-        glibc.apk \
- && rm glibc.apk
+RUN apt-get update \
+  && apt-get install --yes --no-install-recommends \
+    ca-certificates \
+    dumb-init \
+    libcap2 \
+    tzdata \
+  && update-ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 
 ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip \
     nomad_${NOMAD_VERSION}_linux_amd64.zip
@@ -41,7 +29,11 @@ ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}
     nomad_${NOMAD_VERSION}_SHA256SUMS
 ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
     nomad_${NOMAD_VERSION}_SHA256SUMS.sig
-RUN apk add --no-cache --virtual .nomad-deps gnupg \
+
+RUN apt-get update \
+  && apt-get install --yes --no-install-recommends \
+    gnupg \
+    unzip \
   && GNUPGHOME="$(mktemp -d)" \
   && export GNUPGHOME \
   && gpg --keyserver pgp.mit.edu --keyserver keys.openpgp.org --keyserver keyserver.ubuntu.com --recv-keys "C874 011F 0AB4 0511 0D02 1055 3436 5D94 72D7 468F" \
@@ -50,7 +42,12 @@ RUN apk add --no-cache --virtual .nomad-deps gnupg \
   && unzip -d /bin nomad_${NOMAD_VERSION}_linux_amd64.zip \
   && chmod +x /bin/nomad \
   && rm -rf "$GNUPGHOME" nomad_${NOMAD_VERSION}_linux_amd64.zip nomad_${NOMAD_VERSION}_SHA256SUMS nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
-  && apk del .nomad-deps
+  && apt-get autoremove --purge --yes \
+      gnupg \
+      unzip \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN nomad version
 
 EXPOSE 4646 4647 4648 4648/udp
 

--- a/v1.4.x/start.sh
+++ b/v1.4.x/start.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/dumb-init /bin/sh
-# Script created following Hashicorp's model for Consul: 
+# shellcheck shell=dash
+# Script created following Hashicorp's model for Consul:
 # https://github.com/hashicorp/docker-consul/blob/master/0.X/docker-entrypoint.sh
 # Comments in this file originate from the project above, simply replacing 'Consul' with 'Nomad'.
 set -e
@@ -8,6 +9,7 @@ set -e
 # as well as forward signals to all processes in its session. Normally, sh
 # wouldn't do either of these functions so we'd leak zombies as well as do
 # unclean termination of all our sub-processes.
+# As of docker 1.13, using docker run --init achieves the same outcome.
 
 # NOMAD_DATA_DIR is exposed as a volume for possible persistent storage. The
 # NOMAD_CONFIG_DIR isn't exposed as a volume but you can compose additional
@@ -24,7 +26,7 @@ fi
 
 # If the user is trying to run Nomad directly with some arguments, then
 # pass them to Nomad.
-if [ "${1:0:1}" = '-' ]; then
+if [ "$(cut -c 1 "$1")" = '-' ]; then
     set -- nomad "$@"
 fi
 
@@ -48,18 +50,18 @@ fi
 if [ "$1" = 'nomad' ] && [ -z "${NOMAD_DISABLE_PERM_MGMT+x}" ]; then
     # If the data or config dirs are bind mounted then chown them.
     # Note: This checks for root ownership as that's the most common case.
-    if [ "$(stat -c %u $NOMAD_DATA_DIR)" != "$(id -u root)" ]; then
-        chown root:root $NOMAD_DATA_DIR
+    if [ "$(stat -c %u "$NOMAD_DATA_DIR")" != "$(id -u root)" ]; then
+        chown root:root "$NOMAD_DATA_DIR"
     fi
 
     # If requested, set the capability to bind to privileged ports before
     # we drop to the non-root user. Note that this doesn't work with all
     # storage drivers (it won't work with AUFS).
-    if [ -n ${NOMAD+x} ]; then
+    if [ -n "${NOMAD+x}" ]; then
         setcap "cap_net_bind_service=+ep" /bin/nomad
     fi
 
-    set -- su-exec root "$@"
+    exec runuser -u root -- "$@"
 fi
 
 exec "$@"

--- a/v1.5.x/Dockerfile
+++ b/v1.5.x/Dockerfile
@@ -1,41 +1,27 @@
-FROM alpine:3.18.4
+FROM debian:12.2-slim
 
-SHELL ["/bin/ash", "-x", "-c", "-o", "pipefail"]
+SHELL ["/bin/bash", "-x", "-c", "-o", "pipefail"]
 
 # https://releases.hashicorp.com/nomad/
 ARG NOMAD_VERSION
 RUN test -n "$NOMAD_VERSION" || (echo "NOMAD_VERSION argument must be set" && false)
 
-# Based on https://github.com/djenriquez/nomad
-LABEL maintainer="Jonathan Ballet <jon@multani.info>"
-
-RUN addgroup nomad \
- && adduser -S -G nomad nomad \
- && mkdir -p /nomad/data \
- && mkdir -p /etc/nomad \
- && chown -R nomad:nomad /nomad /etc/nomad
+RUN groupadd nomad \
+  && useradd --system --gid nomad nomad \
+  && mkdir --parents /nomad/data \
+  && mkdir --parents /etc/nomad \
+  && chown --recursive nomad:nomad /nomad /etc/nomad
 
 # Allow to fetch artifacts from TLS endpoint during the builds and by Nomad after.
 # Install timezone data so we can run Nomad periodic jobs containing timezone information
-# Ensure bind mount compatible (coreutils) version of df is used (related: hashicorp/nomad#12440, gliderlabs/docker-alpine#97)
-RUN apk --update --no-cache add \
-        ca-certificates \
-        dumb-init \
-        libcap \
-        tzdata \
-        su-exec \
-        coreutils \
-  && update-ca-certificates
-
-# https://github.com/sgerrand/alpine-pkg-glibc/releases
-ARG GLIBC_VERSION=2.34-r0
-
-ADD https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub /etc/apk/keys/sgerrand.rsa.pub
-ADD https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk \
-    glibc.apk
-RUN apk add --no-cache --force-overwrite \
-        glibc.apk \
- && rm glibc.apk
+RUN apt-get update \
+  && apt-get install --yes --no-install-recommends \
+    ca-certificates \
+    dumb-init \
+    libcap2 \
+    tzdata \
+  && update-ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 
 ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip \
     nomad_${NOMAD_VERSION}_linux_amd64.zip
@@ -43,7 +29,11 @@ ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}
     nomad_${NOMAD_VERSION}_SHA256SUMS
 ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
     nomad_${NOMAD_VERSION}_SHA256SUMS.sig
-RUN apk add --no-cache --virtual .nomad-deps gnupg \
+
+RUN apt-get update \
+  && apt-get install --yes --no-install-recommends \
+    gnupg \
+    unzip \
   && GNUPGHOME="$(mktemp -d)" \
   && export GNUPGHOME \
   && gpg --keyserver pgp.mit.edu --keyserver keys.openpgp.org --keyserver keyserver.ubuntu.com --recv-keys "C874 011F 0AB4 0511 0D02 1055 3436 5D94 72D7 468F" \
@@ -52,7 +42,12 @@ RUN apk add --no-cache --virtual .nomad-deps gnupg \
   && unzip -d /bin nomad_${NOMAD_VERSION}_linux_amd64.zip \
   && chmod +x /bin/nomad \
   && rm -rf "$GNUPGHOME" nomad_${NOMAD_VERSION}_linux_amd64.zip nomad_${NOMAD_VERSION}_SHA256SUMS nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
-  && apk del .nomad-deps
+  && apt-get autoremove --purge --yes \
+      gnupg \
+      unzip \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN nomad version
 
 EXPOSE 4646 4647 4648 4648/udp
 

--- a/v1.5.x/start.sh
+++ b/v1.5.x/start.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/dumb-init /bin/sh
-# Script created following Hashicorp's model for Consul: 
+# shellcheck shell=dash
+# Script created following Hashicorp's model for Consul:
 # https://github.com/hashicorp/docker-consul/blob/master/0.X/docker-entrypoint.sh
 # Comments in this file originate from the project above, simply replacing 'Consul' with 'Nomad'.
 set -e
@@ -8,6 +9,7 @@ set -e
 # as well as forward signals to all processes in its session. Normally, sh
 # wouldn't do either of these functions so we'd leak zombies as well as do
 # unclean termination of all our sub-processes.
+# As of docker 1.13, using docker run --init achieves the same outcome.
 
 # NOMAD_DATA_DIR is exposed as a volume for possible persistent storage. The
 # NOMAD_CONFIG_DIR isn't exposed as a volume but you can compose additional
@@ -24,7 +26,7 @@ fi
 
 # If the user is trying to run Nomad directly with some arguments, then
 # pass them to Nomad.
-if [ "${1:0:1}" = '-' ]; then
+if [ "$(cut -c 1 "$1")" = '-' ]; then
     set -- nomad "$@"
 fi
 
@@ -48,18 +50,18 @@ fi
 if [ "$1" = 'nomad' ] && [ -z "${NOMAD_DISABLE_PERM_MGMT+x}" ]; then
     # If the data or config dirs are bind mounted then chown them.
     # Note: This checks for root ownership as that's the most common case.
-    if [ "$(stat -c %u $NOMAD_DATA_DIR)" != "$(id -u root)" ]; then
-        chown root:root $NOMAD_DATA_DIR
+    if [ "$(stat -c %u "$NOMAD_DATA_DIR")" != "$(id -u root)" ]; then
+        chown root:root "$NOMAD_DATA_DIR"
     fi
 
     # If requested, set the capability to bind to privileged ports before
     # we drop to the non-root user. Note that this doesn't work with all
     # storage drivers (it won't work with AUFS).
-    if [ -n ${NOMAD+x} ]; then
+    if [ -n "${NOMAD+x}" ]; then
         setcap "cap_net_bind_service=+ep" /bin/nomad
     fi
 
-    set -- su-exec root "$@"
+    exec runuser -u root -- "$@"
 fi
 
 exec "$@"

--- a/v1.6.x/Dockerfile
+++ b/v1.6.x/Dockerfile
@@ -1,41 +1,27 @@
-FROM alpine:3.18.4
+FROM debian:12.2-slim
 
-SHELL ["/bin/ash", "-x", "-c", "-o", "pipefail"]
+SHELL ["/bin/bash", "-x", "-c", "-o", "pipefail"]
 
 # https://releases.hashicorp.com/nomad/
 ARG NOMAD_VERSION
 RUN test -n "$NOMAD_VERSION" || (echo "NOMAD_VERSION argument must be set" && false)
 
-# Based on https://github.com/djenriquez/nomad
-LABEL maintainer="Jonathan Ballet <jon@multani.info>"
-
-RUN addgroup nomad \
- && adduser -S -G nomad nomad \
- && mkdir -p /nomad/data \
- && mkdir -p /etc/nomad \
- && chown -R nomad:nomad /nomad /etc/nomad
+RUN groupadd nomad \
+  && useradd --system --gid nomad nomad \
+  && mkdir --parents /nomad/data \
+  && mkdir --parents /etc/nomad \
+  && chown --recursive nomad:nomad /nomad /etc/nomad
 
 # Allow to fetch artifacts from TLS endpoint during the builds and by Nomad after.
 # Install timezone data so we can run Nomad periodic jobs containing timezone information
-# Ensure bind mount compatible (coreutils) version of df is used (related: hashicorp/nomad#12440, gliderlabs/docker-alpine#97)
-RUN apk --update --no-cache add \
-        ca-certificates \
-        dumb-init \
-        libcap \
-        tzdata \
-        su-exec \
-        coreutils \
-  && update-ca-certificates
-
-# https://github.com/sgerrand/alpine-pkg-glibc/releases
-ARG GLIBC_VERSION=2.34-r0
-
-ADD https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub /etc/apk/keys/sgerrand.rsa.pub
-ADD https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk \
-    glibc.apk
-RUN apk add --no-cache --force-overwrite \
-        glibc.apk \
- && rm glibc.apk
+RUN apt-get update \
+  && apt-get install --yes --no-install-recommends \
+    ca-certificates \
+    dumb-init \
+    libcap2 \
+    tzdata \
+  && update-ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 
 ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip \
     nomad_${NOMAD_VERSION}_linux_amd64.zip
@@ -43,7 +29,11 @@ ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}
     nomad_${NOMAD_VERSION}_SHA256SUMS
 ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
     nomad_${NOMAD_VERSION}_SHA256SUMS.sig
-RUN apk add --no-cache --virtual .nomad-deps gnupg \
+
+RUN apt-get update \
+  && apt-get install --yes --no-install-recommends \
+    gnupg \
+    unzip \
   && GNUPGHOME="$(mktemp -d)" \
   && export GNUPGHOME \
   && gpg --keyserver pgp.mit.edu --keyserver keys.openpgp.org --keyserver keyserver.ubuntu.com --recv-keys "C874 011F 0AB4 0511 0D02 1055 3436 5D94 72D7 468F" \
@@ -52,7 +42,12 @@ RUN apk add --no-cache --virtual .nomad-deps gnupg \
   && unzip -d /bin nomad_${NOMAD_VERSION}_linux_amd64.zip \
   && chmod +x /bin/nomad \
   && rm -rf "$GNUPGHOME" nomad_${NOMAD_VERSION}_linux_amd64.zip nomad_${NOMAD_VERSION}_SHA256SUMS nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
-  && apk del .nomad-deps
+  && apt-get autoremove --purge --yes \
+      gnupg \
+      unzip \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN nomad version
 
 EXPOSE 4646 4647 4648 4648/udp
 

--- a/v1.6.x/start.sh
+++ b/v1.6.x/start.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/dumb-init /bin/sh
-# Script created following Hashicorp's model for Consul: 
+# shellcheck shell=dash
+# Script created following Hashicorp's model for Consul:
 # https://github.com/hashicorp/docker-consul/blob/master/0.X/docker-entrypoint.sh
 # Comments in this file originate from the project above, simply replacing 'Consul' with 'Nomad'.
 set -e
@@ -8,6 +9,7 @@ set -e
 # as well as forward signals to all processes in its session. Normally, sh
 # wouldn't do either of these functions so we'd leak zombies as well as do
 # unclean termination of all our sub-processes.
+# As of docker 1.13, using docker run --init achieves the same outcome.
 
 # NOMAD_DATA_DIR is exposed as a volume for possible persistent storage. The
 # NOMAD_CONFIG_DIR isn't exposed as a volume but you can compose additional
@@ -24,7 +26,7 @@ fi
 
 # If the user is trying to run Nomad directly with some arguments, then
 # pass them to Nomad.
-if [ "${1:0:1}" = '-' ]; then
+if [ "$(cut -c 1 "$1")" = '-' ]; then
     set -- nomad "$@"
 fi
 
@@ -48,18 +50,18 @@ fi
 if [ "$1" = 'nomad' ] && [ -z "${NOMAD_DISABLE_PERM_MGMT+x}" ]; then
     # If the data or config dirs are bind mounted then chown them.
     # Note: This checks for root ownership as that's the most common case.
-    if [ "$(stat -c %u $NOMAD_DATA_DIR)" != "$(id -u root)" ]; then
-        chown root:root $NOMAD_DATA_DIR
+    if [ "$(stat -c %u "$NOMAD_DATA_DIR")" != "$(id -u root)" ]; then
+        chown root:root "$NOMAD_DATA_DIR"
     fi
 
     # If requested, set the capability to bind to privileged ports before
     # we drop to the non-root user. Note that this doesn't work with all
     # storage drivers (it won't work with AUFS).
-    if [ -n ${NOMAD+x} ]; then
+    if [ -n "${NOMAD+x}" ]; then
         setcap "cap_net_bind_service=+ep" /bin/nomad
     fi
 
-    set -- su-exec root "$@"
+    exec runuser -u root -- "$@"
 fi
 
 exec "$@"

--- a/v1.7.x/Dockerfile
+++ b/v1.7.x/Dockerfile
@@ -1,41 +1,27 @@
-FROM alpine:3.18.4
+FROM debian:12.2-slim
 
-SHELL ["/bin/ash", "-x", "-c", "-o", "pipefail"]
+SHELL ["/bin/bash", "-x", "-c", "-o", "pipefail"]
 
 # https://releases.hashicorp.com/nomad/
 ARG NOMAD_VERSION
 RUN test -n "$NOMAD_VERSION" || (echo "NOMAD_VERSION argument must be set" && false)
 
-# Based on https://github.com/djenriquez/nomad
-LABEL maintainer="Jonathan Ballet <jon@multani.info>"
-
-RUN addgroup nomad \
- && adduser -S -G nomad nomad \
- && mkdir -p /nomad/data \
- && mkdir -p /etc/nomad \
- && chown -R nomad:nomad /nomad /etc/nomad
+RUN groupadd nomad \
+  && useradd --system --gid nomad nomad \
+  && mkdir --parents /nomad/data \
+  && mkdir --parents /etc/nomad \
+  && chown --recursive nomad:nomad /nomad /etc/nomad
 
 # Allow to fetch artifacts from TLS endpoint during the builds and by Nomad after.
 # Install timezone data so we can run Nomad periodic jobs containing timezone information
-# Ensure bind mount compatible (coreutils) version of df is used (related: hashicorp/nomad#12440, gliderlabs/docker-alpine#97)
-RUN apk --update --no-cache add \
-        ca-certificates \
-        dumb-init \
-        libcap \
-        tzdata \
-        su-exec \
-        coreutils \
-  && update-ca-certificates
-
-# https://github.com/sgerrand/alpine-pkg-glibc/releases
-ARG GLIBC_VERSION=2.34-r0
-
-ADD https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub /etc/apk/keys/sgerrand.rsa.pub
-ADD https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk \
-    glibc.apk
-RUN apk add --no-cache --force-overwrite \
-        glibc.apk \
- && rm glibc.apk
+RUN apt-get update \
+  && apt-get install --yes --no-install-recommends \
+    ca-certificates \
+    dumb-init \
+    libcap2 \
+    tzdata \
+  && update-ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 
 ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip \
     nomad_${NOMAD_VERSION}_linux_amd64.zip
@@ -43,7 +29,11 @@ ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}
     nomad_${NOMAD_VERSION}_SHA256SUMS
 ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
     nomad_${NOMAD_VERSION}_SHA256SUMS.sig
-RUN apk add --no-cache --virtual .nomad-deps gnupg \
+
+RUN apt-get update \
+  && apt-get install --yes --no-install-recommends \
+    gnupg \
+    unzip \
   && GNUPGHOME="$(mktemp -d)" \
   && export GNUPGHOME \
   && gpg --keyserver pgp.mit.edu --keyserver keys.openpgp.org --keyserver keyserver.ubuntu.com --recv-keys "C874 011F 0AB4 0511 0D02 1055 3436 5D94 72D7 468F" \
@@ -52,7 +42,12 @@ RUN apk add --no-cache --virtual .nomad-deps gnupg \
   && unzip -d /bin nomad_${NOMAD_VERSION}_linux_amd64.zip \
   && chmod +x /bin/nomad \
   && rm -rf "$GNUPGHOME" nomad_${NOMAD_VERSION}_linux_amd64.zip nomad_${NOMAD_VERSION}_SHA256SUMS nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
-  && apk del .nomad-deps
+  && apt-get autoremove --purge --yes \
+      gnupg \
+      unzip \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN nomad version
 
 EXPOSE 4646 4647 4648 4648/udp
 

--- a/v1.7.x/start.sh
+++ b/v1.7.x/start.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/dumb-init /bin/sh
-# Script created following Hashicorp's model for Consul: 
+# shellcheck shell=dash
+# Script created following Hashicorp's model for Consul:
 # https://github.com/hashicorp/docker-consul/blob/master/0.X/docker-entrypoint.sh
 # Comments in this file originate from the project above, simply replacing 'Consul' with 'Nomad'.
 set -e
@@ -8,6 +9,7 @@ set -e
 # as well as forward signals to all processes in its session. Normally, sh
 # wouldn't do either of these functions so we'd leak zombies as well as do
 # unclean termination of all our sub-processes.
+# As of docker 1.13, using docker run --init achieves the same outcome.
 
 # NOMAD_DATA_DIR is exposed as a volume for possible persistent storage. The
 # NOMAD_CONFIG_DIR isn't exposed as a volume but you can compose additional
@@ -24,7 +26,7 @@ fi
 
 # If the user is trying to run Nomad directly with some arguments, then
 # pass them to Nomad.
-if [ "${1:0:1}" = '-' ]; then
+if [ "$(cut -c 1 "$1")" = '-' ]; then
     set -- nomad "$@"
 fi
 
@@ -48,18 +50,18 @@ fi
 if [ "$1" = 'nomad' ] && [ -z "${NOMAD_DISABLE_PERM_MGMT+x}" ]; then
     # If the data or config dirs are bind mounted then chown them.
     # Note: This checks for root ownership as that's the most common case.
-    if [ "$(stat -c %u $NOMAD_DATA_DIR)" != "$(id -u root)" ]; then
-        chown root:root $NOMAD_DATA_DIR
+    if [ "$(stat -c %u "$NOMAD_DATA_DIR")" != "$(id -u root)" ]; then
+        chown root:root "$NOMAD_DATA_DIR"
     fi
 
     # If requested, set the capability to bind to privileged ports before
     # we drop to the non-root user. Note that this doesn't work with all
     # storage drivers (it won't work with AUFS).
-    if [ -n ${NOMAD+x} ]; then
+    if [ -n "${NOMAD+x}" ]; then
         setcap "cap_net_bind_service=+ep" /bin/nomad
     fi
 
-    set -- su-exec root "$@"
+    exec runuser -u root -- "$@"
 fi
 
 exec "$@"


### PR DESCRIPTION
This replaces the base image from Alpine 3.18 to Debian 12.

The main driver for this change (not implemented yet here) is to easily support arm64 images in the future.

Nomad relies on the gblic for several functionalities and there are no good up to date glibc packages for Alpine.
Changing the underlying libc of the Alpine image is also a bit risky and defeats a bit the purpopse of using this base image in the first place.

This should also help to embark other Nomad plugins, and/or Docker-related plugins by having a more general base image. After all, Nomad itself is most probably expecting to run not on Alpine-based *VMs* in real scenarios.

This increases the size of the final Docker image a bit: in my test, the image increases from 150 MB to 190 MB, but it's still relatively small and Debian opens more possibilities in the future.

See: https://github.com/multani/docker-nomad/discussions/133 and initial experiment in https://github.com/multani/docker-nomad/pull/55.