### PR TITLE
Build images for linux/amd64, linux/arm/v7 and linux/arm64

### DIFF
--- a/.github/workflows/template-build.yml
+++ b/.github/workflows/template-build.yml
@@ -16,9 +16,36 @@ on:
         type: string
 
 jobs:
+  prepare:
+    name: Prepare Build Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.platforms.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create matrix
+        id: platforms
+        run: |
+          echo "matrix=$(echo '"${{ inputs.platforms }}"' | jq -cr '. / ","')" >> "$GITHUB_OUTPUT"
+
+      - name: Show matrix
+        run: |
+          echo ${{ steps.platforms.outputs.matrix }}
+
   build:
     name: Build
     runs-on: ubuntu-latest
+    needs:
+      - prepare
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        platforms: ${{ fromJson(needs.prepare.outputs.matrix) }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -38,7 +65,7 @@ jobs:
         id: docker-setup
         uses: docker/setup-qemu-action@v3
         with:
-          platforms: ${{ inputs.platforms }}
+          platforms: ${{ matrix.platforms }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -51,7 +78,7 @@ jobs:
           load: true  # load the image built locally for later use
           build-args: |-
             NOMAD_VERSION=${{ steps.meta.outputs.nomad }}
-          platforms: ${{ inputs.platforms }}
+          platforms: ${{ matrix.platforms }}
           push: false
           tags: local/nomad:test
 

--- a/.github/workflows/template-release.yml
+++ b/.github/workflows/template-release.yml
@@ -56,6 +56,7 @@ jobs:
         run: |
           echo "nomad=$(cat nomad-version)" >> "$GITHUB_OUTPUT"
           echo "git=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          echo "pretty-platforms=$(echo ${{ inputs.platforms }} | sed 's/,/`, `/g')" >> "$GITHUB_OUTPUT"
 
       - name: Release
         uses: softprops/action-gh-release@v1
@@ -76,3 +77,5 @@ jobs:
               ```shell
               docker pull multani/nomad:${{ steps.meta.outputs.git }}
               ```
+
+            The image is available on the following platforms: `${{ steps.meta.outputs.pretty-platforms }}`.

--- a/.github/workflows/v1.2.x-build.yml
+++ b/.github/workflows/v1.2.x-build.yml
@@ -18,5 +18,5 @@ jobs:
     name: Test
     uses: ./.github/workflows/template-build.yml
     with:
-      platforms: linux/amd64
+      platforms: linux/amd64,linux/arm/v7,linux/arm64
       directory: v1.2.x

--- a/.github/workflows/v1.2.x-release.yml
+++ b/.github/workflows/v1.2.x-release.yml
@@ -15,5 +15,5 @@ jobs:
     uses: ./.github/workflows/template-release.yml
     secrets: inherit
     with:
-      platforms: linux/amd64
+      platforms: linux/amd64,linux/arm/v7,linux/arm64
       directory: v1.2.x

--- a/.github/workflows/v1.3.x-build.yml
+++ b/.github/workflows/v1.3.x-build.yml
@@ -18,5 +18,5 @@ jobs:
     name: Test
     uses: ./.github/workflows/template-build.yml
     with:
-      platforms: linux/amd64
+      platforms: linux/amd64,linux/arm/v7,linux/arm64
       directory: v1.3.x

--- a/.github/workflows/v1.3.x-release.yml
+++ b/.github/workflows/v1.3.x-release.yml
@@ -15,5 +15,5 @@ jobs:
     uses: ./.github/workflows/template-release.yml
     secrets: inherit
     with:
-      platforms: linux/amd64
+      platforms: linux/amd64,linux/arm/v7,linux/arm64
       directory: v1.3.x

--- a/.github/workflows/v1.4.x-build.yml
+++ b/.github/workflows/v1.4.x-build.yml
@@ -18,5 +18,5 @@ jobs:
     name: Test
     uses: ./.github/workflows/template-build.yml
     with:
-      platforms: linux/amd64
+      platforms: linux/amd64,linux/arm/v7,linux/arm64
       directory: v1.4.x

--- a/.github/workflows/v1.4.x-release.yml
+++ b/.github/workflows/v1.4.x-release.yml
@@ -15,5 +15,5 @@ jobs:
     uses: ./.github/workflows/template-release.yml
     secrets: inherit
     with:
-      platforms: linux/amd64
+      platforms: linux/amd64,linux/arm/v7,linux/arm64
       directory: v1.4.x

--- a/.github/workflows/v1.5.x-build.yml
+++ b/.github/workflows/v1.5.x-build.yml
@@ -18,5 +18,5 @@ jobs:
     name: Test
     uses: ./.github/workflows/template-build.yml
     with:
-      platforms: linux/amd64
+      platforms: linux/amd64,linux/arm/v7,linux/arm64
       directory: v1.5.x

--- a/.github/workflows/v1.5.x-release.yml
+++ b/.github/workflows/v1.5.x-release.yml
@@ -15,5 +15,5 @@ jobs:
     uses: ./.github/workflows/template-release.yml
     secrets: inherit
     with:
-      platforms: linux/amd64
+      platforms: linux/amd64,linux/arm/v7,linux/arm64
       directory: v1.5.x

--- a/.github/workflows/v1.6.x-build.yml
+++ b/.github/workflows/v1.6.x-build.yml
@@ -18,5 +18,5 @@ jobs:
     name: Test
     uses: ./.github/workflows/template-build.yml
     with:
-      platforms: linux/amd64
+      platforms: linux/amd64,linux/arm/v7,linux/arm64
       directory: v1.6.x

--- a/.github/workflows/v1.6.x-release.yml
+++ b/.github/workflows/v1.6.x-release.yml
@@ -15,5 +15,5 @@ jobs:
     uses: ./.github/workflows/template-release.yml
     secrets: inherit
     with:
-      platforms: linux/amd64
+      platforms: linux/amd64,linux/arm/v7,linux/arm64
       directory: v1.6.x

--- a/.github/workflows/v1.7.x-build.yml
+++ b/.github/workflows/v1.7.x-build.yml
@@ -18,5 +18,5 @@ jobs:
     name: Test
     uses: ./.github/workflows/template-build.yml
     with:
-      platforms: linux/amd64
+      platforms: linux/amd64,linux/arm/v7,linux/arm64
       directory: v1.7.x

--- a/.github/workflows/v1.7.x-release.yml
+++ b/.github/workflows/v1.7.x-release.yml
@@ -15,5 +15,5 @@ jobs:
     uses: ./.github/workflows/template-release.yml
     secrets: inherit
     with:
-      platforms: linux/amd64
+      platforms: linux/amd64,linux/arm/v7,linux/arm64
       directory: v1.7.x

--- a/v1.2.x/Dockerfile
+++ b/v1.2.x/Dockerfile
@@ -1,4 +1,8 @@
-FROM debian:12.2-slim
+FROM --platform=$TARGETPLATFORM debian:12.2-slim
+
+# Fetch the target information injected by Docker build
+ARG TARGETOS
+ARG TARGETARCH
 
 SHELL ["/bin/bash", "-x", "-c", "-o", "pipefail"]
 
@@ -23,8 +27,8 @@ RUN apt-get update \
   && update-ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
-ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip \
-    nomad_${NOMAD_VERSION}_linux_amd64.zip
+ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip \
+    nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip
 ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_SHA256SUMS \
     nomad_${NOMAD_VERSION}_SHA256SUMS
 ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
@@ -38,10 +42,10 @@ RUN apt-get update \
   && export GNUPGHOME \
   && gpg --keyserver pgp.mit.edu --keyserver keys.openpgp.org --keyserver keyserver.ubuntu.com --recv-keys "C874 011F 0AB4 0511 0D02 1055 3436 5D94 72D7 468F" \
   && gpg --batch --verify nomad_${NOMAD_VERSION}_SHA256SUMS.sig nomad_${NOMAD_VERSION}_SHA256SUMS \
-  && grep nomad_${NOMAD_VERSION}_linux_amd64.zip nomad_${NOMAD_VERSION}_SHA256SUMS | sha256sum -c \
-  && unzip -d /bin nomad_${NOMAD_VERSION}_linux_amd64.zip \
+  && grep nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip nomad_${NOMAD_VERSION}_SHA256SUMS | sha256sum -c \
+  && unzip -d /bin nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip \
   && chmod +x /bin/nomad \
-  && rm -rf "$GNUPGHOME" nomad_${NOMAD_VERSION}_linux_amd64.zip nomad_${NOMAD_VERSION}_SHA256SUMS nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
+  && rm -rf "$GNUPGHOME" nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip nomad_${NOMAD_VERSION}_SHA256SUMS nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
   && apt-get autoremove --purge --yes \
       gnupg \
       unzip \

--- a/v1.3.x/Dockerfile
+++ b/v1.3.x/Dockerfile
@@ -1,4 +1,8 @@
-FROM debian:12.2-slim
+FROM --platform=$TARGETPLATFORM debian:12.2-slim
+
+# Fetch the target information injected by Docker build
+ARG TARGETOS
+ARG TARGETARCH
 
 SHELL ["/bin/bash", "-x", "-c", "-o", "pipefail"]
 
@@ -23,8 +27,8 @@ RUN apt-get update \
   && update-ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
-ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip \
-    nomad_${NOMAD_VERSION}_linux_amd64.zip
+ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip \
+    nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip
 ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_SHA256SUMS \
     nomad_${NOMAD_VERSION}_SHA256SUMS
 ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
@@ -38,10 +42,10 @@ RUN apt-get update \
   && export GNUPGHOME \
   && gpg --keyserver pgp.mit.edu --keyserver keys.openpgp.org --keyserver keyserver.ubuntu.com --recv-keys "C874 011F 0AB4 0511 0D02 1055 3436 5D94 72D7 468F" \
   && gpg --batch --verify nomad_${NOMAD_VERSION}_SHA256SUMS.sig nomad_${NOMAD_VERSION}_SHA256SUMS \
-  && grep nomad_${NOMAD_VERSION}_linux_amd64.zip nomad_${NOMAD_VERSION}_SHA256SUMS | sha256sum -c \
-  && unzip -d /bin nomad_${NOMAD_VERSION}_linux_amd64.zip \
+  && grep nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip nomad_${NOMAD_VERSION}_SHA256SUMS | sha256sum -c \
+  && unzip -d /bin nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip \
   && chmod +x /bin/nomad \
-  && rm -rf "$GNUPGHOME" nomad_${NOMAD_VERSION}_linux_amd64.zip nomad_${NOMAD_VERSION}_SHA256SUMS nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
+  && rm -rf "$GNUPGHOME" nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip nomad_${NOMAD_VERSION}_SHA256SUMS nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
   && apt-get autoremove --purge --yes \
       gnupg \
       unzip \

--- a/v1.4.x/Dockerfile
+++ b/v1.4.x/Dockerfile
@@ -1,4 +1,8 @@
-FROM debian:12.2-slim
+FROM --platform=$TARGETPLATFORM debian:12.2-slim
+
+# Fetch the target information injected by Docker build
+ARG TARGETOS
+ARG TARGETARCH
 
 SHELL ["/bin/bash", "-x", "-c", "-o", "pipefail"]
 
@@ -23,8 +27,8 @@ RUN apt-get update \
   && update-ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
-ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip \
-    nomad_${NOMAD_VERSION}_linux_amd64.zip
+ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip \
+    nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip
 ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_SHA256SUMS \
     nomad_${NOMAD_VERSION}_SHA256SUMS
 ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
@@ -38,10 +42,10 @@ RUN apt-get update \
   && export GNUPGHOME \
   && gpg --keyserver pgp.mit.edu --keyserver keys.openpgp.org --keyserver keyserver.ubuntu.com --recv-keys "C874 011F 0AB4 0511 0D02 1055 3436 5D94 72D7 468F" \
   && gpg --batch --verify nomad_${NOMAD_VERSION}_SHA256SUMS.sig nomad_${NOMAD_VERSION}_SHA256SUMS \
-  && grep nomad_${NOMAD_VERSION}_linux_amd64.zip nomad_${NOMAD_VERSION}_SHA256SUMS | sha256sum -c \
-  && unzip -d /bin nomad_${NOMAD_VERSION}_linux_amd64.zip \
+  && grep nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip nomad_${NOMAD_VERSION}_SHA256SUMS | sha256sum -c \
+  && unzip -d /bin nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip \
   && chmod +x /bin/nomad \
-  && rm -rf "$GNUPGHOME" nomad_${NOMAD_VERSION}_linux_amd64.zip nomad_${NOMAD_VERSION}_SHA256SUMS nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
+  && rm -rf "$GNUPGHOME" nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip nomad_${NOMAD_VERSION}_SHA256SUMS nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
   && apt-get autoremove --purge --yes \
       gnupg \
       unzip \

--- a/v1.5.x/Dockerfile
+++ b/v1.5.x/Dockerfile
@@ -1,4 +1,8 @@
-FROM debian:12.2-slim
+FROM --platform=$TARGETPLATFORM debian:12.2-slim
+
+# Fetch the target information injected by Docker build
+ARG TARGETOS
+ARG TARGETARCH
 
 SHELL ["/bin/bash", "-x", "-c", "-o", "pipefail"]
 
@@ -23,8 +27,8 @@ RUN apt-get update \
   && update-ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
-ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip \
-    nomad_${NOMAD_VERSION}_linux_amd64.zip
+ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip \
+    nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip
 ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_SHA256SUMS \
     nomad_${NOMAD_VERSION}_SHA256SUMS
 ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
@@ -38,10 +42,10 @@ RUN apt-get update \
   && export GNUPGHOME \
   && gpg --keyserver pgp.mit.edu --keyserver keys.openpgp.org --keyserver keyserver.ubuntu.com --recv-keys "C874 011F 0AB4 0511 0D02 1055 3436 5D94 72D7 468F" \
   && gpg --batch --verify nomad_${NOMAD_VERSION}_SHA256SUMS.sig nomad_${NOMAD_VERSION}_SHA256SUMS \
-  && grep nomad_${NOMAD_VERSION}_linux_amd64.zip nomad_${NOMAD_VERSION}_SHA256SUMS | sha256sum -c \
-  && unzip -d /bin nomad_${NOMAD_VERSION}_linux_amd64.zip \
+  && grep nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip nomad_${NOMAD_VERSION}_SHA256SUMS | sha256sum -c \
+  && unzip -d /bin nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip \
   && chmod +x /bin/nomad \
-  && rm -rf "$GNUPGHOME" nomad_${NOMAD_VERSION}_linux_amd64.zip nomad_${NOMAD_VERSION}_SHA256SUMS nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
+  && rm -rf "$GNUPGHOME" nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip nomad_${NOMAD_VERSION}_SHA256SUMS nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
   && apt-get autoremove --purge --yes \
       gnupg \
       unzip \

--- a/v1.6.x/Dockerfile
+++ b/v1.6.x/Dockerfile
@@ -1,4 +1,8 @@
-FROM debian:12.2-slim
+FROM --platform=$TARGETPLATFORM debian:12.2-slim
+
+# Fetch the target information injected by Docker build
+ARG TARGETOS
+ARG TARGETARCH
 
 SHELL ["/bin/bash", "-x", "-c", "-o", "pipefail"]
 
@@ -23,8 +27,8 @@ RUN apt-get update \
   && update-ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
-ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip \
-    nomad_${NOMAD_VERSION}_linux_amd64.zip
+ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip \
+    nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip
 ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_SHA256SUMS \
     nomad_${NOMAD_VERSION}_SHA256SUMS
 ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
@@ -38,10 +42,10 @@ RUN apt-get update \
   && export GNUPGHOME \
   && gpg --keyserver pgp.mit.edu --keyserver keys.openpgp.org --keyserver keyserver.ubuntu.com --recv-keys "C874 011F 0AB4 0511 0D02 1055 3436 5D94 72D7 468F" \
   && gpg --batch --verify nomad_${NOMAD_VERSION}_SHA256SUMS.sig nomad_${NOMAD_VERSION}_SHA256SUMS \
-  && grep nomad_${NOMAD_VERSION}_linux_amd64.zip nomad_${NOMAD_VERSION}_SHA256SUMS | sha256sum -c \
-  && unzip -d /bin nomad_${NOMAD_VERSION}_linux_amd64.zip \
+  && grep nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip nomad_${NOMAD_VERSION}_SHA256SUMS | sha256sum -c \
+  && unzip -d /bin nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip \
   && chmod +x /bin/nomad \
-  && rm -rf "$GNUPGHOME" nomad_${NOMAD_VERSION}_linux_amd64.zip nomad_${NOMAD_VERSION}_SHA256SUMS nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
+  && rm -rf "$GNUPGHOME" nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip nomad_${NOMAD_VERSION}_SHA256SUMS nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
   && apt-get autoremove --purge --yes \
       gnupg \
       unzip \

--- a/v1.7.x/Dockerfile
+++ b/v1.7.x/Dockerfile
@@ -1,4 +1,8 @@
-FROM debian:12.2-slim
+FROM --platform=$TARGETPLATFORM debian:12.2-slim
+
+# Fetch the target information injected by Docker build
+ARG TARGETOS
+ARG TARGETARCH
 
 SHELL ["/bin/bash", "-x", "-c", "-o", "pipefail"]
 
@@ -23,8 +27,8 @@ RUN apt-get update \
   && update-ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
-ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip \
-    nomad_${NOMAD_VERSION}_linux_amd64.zip
+ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip \
+    nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip
 ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_SHA256SUMS \
     nomad_${NOMAD_VERSION}_SHA256SUMS
 ADD https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
@@ -38,10 +42,10 @@ RUN apt-get update \
   && export GNUPGHOME \
   && gpg --keyserver pgp.mit.edu --keyserver keys.openpgp.org --keyserver keyserver.ubuntu.com --recv-keys "C874 011F 0AB4 0511 0D02 1055 3436 5D94 72D7 468F" \
   && gpg --batch --verify nomad_${NOMAD_VERSION}_SHA256SUMS.sig nomad_${NOMAD_VERSION}_SHA256SUMS \
-  && grep nomad_${NOMAD_VERSION}_linux_amd64.zip nomad_${NOMAD_VERSION}_SHA256SUMS | sha256sum -c \
-  && unzip -d /bin nomad_${NOMAD_VERSION}_linux_amd64.zip \
+  && grep nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip nomad_${NOMAD_VERSION}_SHA256SUMS | sha256sum -c \
+  && unzip -d /bin nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip \
   && chmod +x /bin/nomad \
-  && rm -rf "$GNUPGHOME" nomad_${NOMAD_VERSION}_linux_amd64.zip nomad_${NOMAD_VERSION}_SHA256SUMS nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
+  && rm -rf "$GNUPGHOME" nomad_${NOMAD_VERSION}_${TARGETOS}_${TARGETARCH}.zip nomad_${NOMAD_VERSION}_SHA256SUMS nomad_${NOMAD_VERSION}_SHA256SUMS.sig \
   && apt-get autoremove --purge --yes \
       gnupg \
       unzip \


### PR DESCRIPTION
In addition to the previous linux/amd64 platform, this now builds the Docker images for the additional platforms:

* linux/arm/v7
* linux/arm64

See relevant discussion: https://github.com/multani/docker-nomad/discussions/38 and previous pull request https://github.com/multani/docker-nomad/pull/55