### PR TITLE
Disable arm/v7 support

### DIFF
--- a/.github/workflows/v1.8.x-build.yml
+++ b/.github/workflows/v1.8.x-build.yml
@@ -18,5 +18,5 @@ jobs:
     name: Test
     uses: ./.github/workflows/template-build.yml
     with:
-      platforms: linux/amd64,linux/arm/v7,linux/arm64
+      platforms: linux/amd64,linux/arm64
       directory: v1.8.x

--- a/.github/workflows/v1.8.x-release.yml
+++ b/.github/workflows/v1.8.x-release.yml
@@ -15,5 +15,5 @@ jobs:
     uses: ./.github/workflows/template-release.yml
     secrets: inherit
     with:
-      platforms: linux/amd64,linux/arm/v7,linux/arm64
+      platforms: linux/amd64,linux/arm64
       directory: v1.8.x

--- a/.github/workflows/v1.9.x-build.yml
+++ b/.github/workflows/v1.9.x-build.yml
@@ -18,5 +18,5 @@ jobs:
     name: Test
     uses: ./.github/workflows/template-build.yml
     with:
-      platforms: linux/amd64,linux/arm/v7,linux/arm64
+      platforms: linux/amd64,linux/arm64
       directory: v1.9.x

--- a/.github/workflows/v1.9.x-release.yml
+++ b/.github/workflows/v1.9.x-release.yml
@@ -15,5 +15,5 @@ jobs:
     uses: ./.github/workflows/template-release.yml
     secrets: inherit
     with:
-      platforms: linux/amd64,linux/arm/v7,linux/arm64
+      platforms: linux/amd64,linux/arm64
       directory: v1.9.x


### PR DESCRIPTION
It's not available anymore starting from Nomad 1.8.3.

[1.8.2](https://releases.hashicorp.com/nomad/1.8.2/): 
![image](https://github.com/user-attachments/assets/b99ee8a5-7fd2-4748-9084-7436fde63254)

[1.8.3](https://releases.hashicorp.com/nomad/1.8.3/):
![image](https://github.com/user-attachments/assets/4ae2f57a-3fd0-4e67-9849-8c739b99d1b4)
