### PR TITLE
Add missing iproute2 package

### DIFF
--- a/v1.10.x/Dockerfile
+++ b/v1.10.x/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update \
   && apt-get install --yes --no-install-recommends \
     ca-certificates \
     dumb-init \
+    iproute2 \
     libcap2 \
     tzdata \
   && update-ca-certificates \

--- a/v1.2.x/Dockerfile
+++ b/v1.2.x/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update \
   && apt-get install --yes --no-install-recommends \
     ca-certificates \
     dumb-init \
+    iproute2 \
     libcap2 \
     tzdata \
   && update-ca-certificates \

--- a/v1.3.x/Dockerfile
+++ b/v1.3.x/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update \
   && apt-get install --yes --no-install-recommends \
     ca-certificates \
     dumb-init \
+    iproute2 \
     libcap2 \
     tzdata \
   && update-ca-certificates \

--- a/v1.4.x/Dockerfile
+++ b/v1.4.x/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update \
   && apt-get install --yes --no-install-recommends \
     ca-certificates \
     dumb-init \
+    iproute2 \
     libcap2 \
     tzdata \
   && update-ca-certificates \

--- a/v1.5.x/Dockerfile
+++ b/v1.5.x/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update \
   && apt-get install --yes --no-install-recommends \
     ca-certificates \
     dumb-init \
+    iproute2 \
     libcap2 \
     tzdata \
   && update-ca-certificates \

--- a/v1.6.x/Dockerfile
+++ b/v1.6.x/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update \
   && apt-get install --yes --no-install-recommends \
     ca-certificates \
     dumb-init \
+    iproute2 \
     libcap2 \
     tzdata \
   && update-ca-certificates \

--- a/v1.7.x/Dockerfile
+++ b/v1.7.x/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update \
   && apt-get install --yes --no-install-recommends \
     ca-certificates \
     dumb-init \
+    iproute2 \
     libcap2 \
     tzdata \
   && update-ca-certificates \

--- a/v1.8.x/Dockerfile
+++ b/v1.8.x/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update \
   && apt-get install --yes --no-install-recommends \
     ca-certificates \
     dumb-init \
+    iproute2 \
     libcap2 \
     tzdata \
   && update-ca-certificates \

--- a/v1.9.x/Dockerfile
+++ b/v1.9.x/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update \
   && apt-get install --yes --no-install-recommends \
     ca-certificates \
     dumb-init \
+    iproute2 \
     libcap2 \
     tzdata \
   && update-ca-certificates \


### PR DESCRIPTION
This prevented Nomad from starting as a client with the following error:

> agent: error starting agent: error="client setup failed: fingerprinting failed: Error while detecting network interface  during fingerprinting: fork/exec /sbin/ip: no such file or directory"

Nomad in server mode could start correctly though.

Fix: #321 